### PR TITLE
feat: 0.2.0 Add tee functionality

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,6 @@
 #define SPURO_IMPLEMENTATION
 #include "spuro.h"
+#include <unistd.h> // for usleep
 
 int main(void)
 {
@@ -28,5 +29,13 @@ int main(void)
     spr_ftracef(stdout, "This is traced.\n");
     spr_fttracef(stdout, "This is both timed and traced.\n");
     spr_fp_printf("anvil.log", "This can log to a file by passing its runtime path as a string.");
+
+    printf("\n\n\n\n\n");
+    int total = 123; // Example total value (not 100)
+    for (int i = 0; i <= total; ++i) {
+        spr_print_progress_bar_(SPR_DEFAULT, SPR_RED, SPR_HERE, i, total);
+        usleep(100000); // Sleep for 100 milliseconds
+    }
+    printf("\n");
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -42,10 +42,16 @@ int main(void)
 
     printf("\n\n\n\n\n");
     int total = 123; // Example total value (not 100)
+
+    printf("\033[?25l"); // Hide cursor
+    fflush(stdout);
+
     for (int i = 0; i <= total; ++i) {
         spr_print_progress_bar_(SPR_DEFAULT, SPR_RED, SPR_HERE, i, total);
         usleep(100000); // Sleep for 100 milliseconds
     }
+    printf("\033[?25h"); // Hide cursor
+    fflush(stdout);
     printf("\n");
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,7 @@
 #define SPURO_IMPLEMENTATION
 #include "spuro.h"
 #include <unistd.h> // for usleep
+#include <assert.h>
 
 int main(void)
 {
@@ -29,6 +30,15 @@ int main(void)
     spr_ftracef(stdout, "This is traced.\n");
     spr_fttracef(stdout, "This is both timed and traced.\n");
     spr_fp_printf("anvil.log", "This can log to a file by passing its runtime path as a string.");
+
+    Spuro s4 = spr_new_file(stdout);
+    s4.lvl = SPR_DEBUG;
+
+    spr_add_tee(&s3, &s4);
+
+    assert(s3.tee_count == 1);
+
+    spr_logf_to(s3, SPR_DEBUG, "This logs to s3 and s4");
 
     printf("\n\n\n\n\n");
     int total = 123; // Example total value (not 100)

--- a/src/spuro.h
+++ b/src/spuro.h
@@ -150,6 +150,7 @@ Spuro spr_new_(FILE* fp, bool check_file, SpuroOut out, SpuroLevel level, bool t
 bool spr_setfile(Spuro *spr, FILE *file);
 
 void spr_logf_(const Spuro spr, SpuroLevel level, SpuroColor color, SpuroLoc loc, bool traced, bool timed, const char *format, ...);
+void spr_logvf_(const Spuro spr, SpuroLevel level, SpuroColor color, SpuroLoc loc, bool traced, bool timed, const char* format, va_list args);
 void spr_print_progress_bar_(const Spuro spr, SpuroColor color, SpuroLoc loc, int progress, int total);
 
 // Utility log macros
@@ -402,6 +403,7 @@ bool spr_setfile(struct Spuro *spr, FILE *file)
 
 /**
  * Takes a Spuro, a format string, and variadic arguments.
+ * Wrapper over spr_logvf_().
  * @param spr The Spuro to log with.
  * @param level The SpuroLevel for the message.
  * @param color The SpuroColor for the message.
@@ -410,7 +412,16 @@ bool spr_setfile(struct Spuro *spr, FILE *file)
  * @param timed Timestamp message when true.
  * @param format The format string for message.
  */
-void spr_logf_(const Spuro spr, SpuroLevel level, SpuroColor color, SpuroLoc loc, bool traced, bool timed, const char *format, ...)
+void spr_logf_(const Spuro spr, SpuroLevel level, SpuroColor color, SpuroLoc loc,
+               bool traced, bool timed, const char *format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    spr_logvf_(spr, level, color, loc, traced, timed, format, args);
+    va_end(args);
+}
+
+void spr_logvf_(const Spuro spr, SpuroLevel level, SpuroColor color, SpuroLoc loc, bool traced, bool timed, const char *format, va_list args)
 {
     const char* lvl_tag;
     char lvl_str[50] = "";
@@ -546,9 +557,6 @@ void spr_logf_(const Spuro spr, SpuroLevel level, SpuroColor color, SpuroLoc loc
     }
     }
 
-    va_list args;
-    va_start(args, format);
-
     if (level == SPR_NOLVL) {
         if (!do_color) {
             fprintf(out, "%s%s%s", trace_str, time_tag, lvl_str);
@@ -569,7 +577,6 @@ void spr_logf_(const Spuro spr, SpuroLevel level, SpuroColor color, SpuroLoc loc
             fprintf(out, "]%s\n", SPR_COLORSTR_RESET);
         }
     }
-    va_end(args);
 }
 
 void spr_print_progress_bar_(const Spuro spr, SpuroColor color, SpuroLoc loc, int progress, int total) {

--- a/src/spuro.h
+++ b/src/spuro.h
@@ -67,12 +67,18 @@ const char* spr_color_string(SpuroColor color);
 
 #define SPR_MAX_TEES 8
 
+typedef enum SpuroColored {
+    SPR_COLORED_ALWAYS = 0,
+    SPR_COLORED_AUTO,
+    SPR_COLORED_NONE
+} SpuroColored;
+
 typedef struct Spuro {
     SpuroOut out;
     FILE* fp;
     SpuroLevel lvl;
     bool timed;
-    bool colored;
+    SpuroColored colored;
     bool traced;
     struct Spuro* tees[SPR_MAX_TEES];
     int tee_count;
@@ -101,16 +107,16 @@ typedef struct SpuroLoc {
     .fp = NULL, \
     .lvl = SPR_LVL_MAX, \
     .timed = false, \
-    .colored = false, \
+    .colored = SPR_COLORED_AUTO, \
     .traced = false, \
 }
 #endif // SPR_DEFAULT
 
 const char* spr_version_string(void);
-Spuro spr_new_(FILE* fp, bool check_file, SpuroOut out, SpuroLevel level, bool timed, bool colored, bool traced);
+Spuro spr_new_(FILE* fp, bool check_file, SpuroOut out, SpuroLevel level, bool timed, SpuroColored colored, bool traced);
 bool spr_add_tee(Spuro* spr, Spuro* tee);
 
-#define spr_new(out) spr_new_(NULL, false, (out), SPR_DEFAULT.lvl, false, false, false)
+#define spr_new(out) spr_new_(NULL, false, (out), SPR_DEFAULT.lvl, false, SPR_COLORED_AUTO, false)
 
 // Utility new() macros
 
@@ -120,37 +126,37 @@ bool spr_add_tee(Spuro* spr, Spuro* tee);
 // Utility new_file() macros
 
 #define spr_new_file_conf(fp, timed, colored, traced) spr_new_((fp), true, SPR_FILE, SPR_NOLVL, (timed), (colored), (traced))
-#define spr_new_file(fp) spr_new_file_conf((fp),false,false,false)
-#define spr_new_file_timed(fp) spr_new_file_conf((fp),true,false,false)
-#define spr_new_file_traced(fp) spr_new_file_conf((fp),false,false,true)
-#define spr_new_file_tt(fp) spr_new_file_conf((fp),true,false,true)
+#define spr_new_file(fp) spr_new_file_conf((fp),false,SPR_COLORED_AUTO,false)
+#define spr_new_file_timed(fp) spr_new_file_conf((fp),true,SPR_COLORED_AUTO,false)
+#define spr_new_file_traced(fp) spr_new_file_conf((fp),false,SPR_COLORED_AUTO,true)
+#define spr_new_file_tt(fp) spr_new_file_conf((fp),true,SPR_COLORED_AUTO,true)
 
 // Utility new_file() level + conf macros
 #define spr_new_file_lvl_conf(fp, level, timed, colored, traced) spr_new_((fp), true, SPR_FILE, (level), (timed), (colored), (traced))
-#define spr_new_file_timed_to(fp, level) spr_new_lvl_conf((fp), (level), true,false,false)
-#define spr_new_file_traced_to(fp, level) spr_new_lvl_conf((fp), (level), false,false,true)
-#define spr_new_file_tt_to(fp, level) spr_new_lvl_conf((fp), (level),true,false,true)
+#define spr_new_file_timed_to(fp, level) spr_new_lvl_conf((fp), (level), true,SPR_COLORED_AUTO,false)
+#define spr_new_file_traced_to(fp, level) spr_new_lvl_conf((fp), (level), false,SPR_COLORED_AUTO,true)
+#define spr_new_file_tt_to(fp, level) spr_new_lvl_conf((fp), (level),true,SPR_COLORED_AUTO,true)
 
 // Utility new() conf macros
 
-#define spr_new_colored(out) spr_new_conf((out),false,true,false)
-#define spr_new_timed(out) spr_new_conf((out),true,false,false)
-#define spr_new_tc(out) spr_new_conf((out),true,true,false)
-#define spr_new_traced(out) spr_new_conf((out),false,false,true)
-#define spr_new_ttraced(out) spr_new_conf((out),true,false,true)
-#define spr_new_ctraced(out) spr_new_conf((out),false,true,true)
-#define spr_new_tctraced(out) spr_newconf((out),true,true,true)
+#define spr_new_colored(out) spr_new_conf((out),false,SPR_COLORED_ALWAYS,false)
+#define spr_new_timed(out) spr_new_conf((out),true,SPR_COLORED_AUTO,false)
+#define spr_new_tc(out) spr_new_conf((out),true,SPR_COLORED_ALWAYS,false)
+#define spr_new_traced(out) spr_new_conf((out),false,SPR_COLORED_AUTO,true)
+#define spr_new_ttraced(out) spr_new_conf((out),true,SPR_COLORED_AUTO,true)
+#define spr_new_ctraced(out) spr_new_conf((out),false,SPR_COLORED_ALWAYS,true)
+#define spr_new_tctraced(out) spr_newconf((out),true,SPR_COLORED_ALWAYS,true)
 
 // Utility new() level + conf macros
 
-#define spr_new_level(out, level) spr_new_lvl_conf((out),(level),false,false,false)
-#define spr_new_level_timed(out, level) spr_new_lvl_conf((out),(level),true,false,false)
-#define spr_new_level_colored(out, level) spr_new_lvl_conf((out),(level),false,true,false)
-#define spr_new_level_tc(out, level) spr_new_lvl_conf((out),(level),true,true,false)
-#define spr_new_traced_level(out, level) spr_new_lvl_conf((out),(level),false,false,true)
-#define spr_new_ttraced_level(out, level) spr_new_lvl_conf((out),(level),true,false,true)
-#define spr_new_ctraced_level(out, level) spr_new_lvl_conf((out),(level),false,true,true)
-#define spr_new_tctraced_level(out, level) spr_new_lvl_conf((out),(level),true,true,true)
+#define spr_new_level(out, level) spr_new_lvl_conf((out),(level),false,SPR_COLORED_AUTO,false)
+#define spr_new_level_timed(out, level) spr_new_lvl_conf((out),(level),true,SPR_COLORED_AUTO,false)
+#define spr_new_level_colored(out, level) spr_new_lvl_conf((out),(level),false,SPR_COLORED_ALWAYS,false)
+#define spr_new_level_tc(out, level) spr_new_lvl_conf((out),(level),true,SPR_COLORED_ALWAYS,false)
+#define spr_new_traced_level(out, level) spr_new_lvl_conf((out),(level),false,SPR_COLORED_AUTO,true)
+#define spr_new_ttraced_level(out, level) spr_new_lvl_conf((out),(level),true,SPR_COLORED_AUTO,true)
+#define spr_new_ctraced_level(out, level) spr_new_lvl_conf((out),(level),false,SPR_COLORED_ALWAYS,true)
+#define spr_new_tctraced_level(out, level) spr_new_lvl_conf((out),(level),true,SPR_COLORED_ALWAYS,true)
 
 bool spr_setfile(Spuro *spr, FILE *file);
 
@@ -372,7 +378,7 @@ const char* spr_color_string(SpuroColor color)
     }
 }
 
-Spuro spr_new_(FILE* fp, bool check_file, SpuroOut out, SpuroLevel level, bool timed, bool colored, bool traced)
+Spuro spr_new_(FILE* fp, bool check_file, SpuroOut out, SpuroLevel level, bool timed, SpuroColored colored, bool traced)
 {
     if (check_file) {
         if (!fp) {
@@ -482,9 +488,9 @@ void spr_logvf_(const Spuro spr, SpuroLevel level, SpuroColor color, SpuroLoc lo
 
     bool do_color = false;
     if (color == SPR_COLOR_AUTO) {
-        do_color = spr.colored;
+        do_color = spr.colored == SPR_COLORED_ALWAYS;
     } else {
-        do_color = (spr.out != SPR_FILE);
+        do_color = (spr.colored != SPR_COLORED_NONE && spr.out != SPR_FILE);
     }
 #ifdef _WIN32
     /**


### PR DESCRIPTION
### Added
- Add `spr_add_tee()` to allow coupling multiple `Spuro`
  - Closes #2
- Add `spr_print_progress_bar_()`
- Add `SpuroColored` to allow turning off all color output (via `SPR_COLORED_NONE`)


### Changed

- Now `spr_logf_()` is a thin wrapper over `spr_logvf_()`