### PR TITLE
fix: correct typo in spr_new_tctraced macro (missing underscore in spr_new_conf)

### DIFF
--- a/src/spuro.h
+++ b/src/spuro.h
@@ -146,7 +146,7 @@ bool spr_add_tee(Spuro* spr, Spuro* tee);
 #define spr_new_traced(out) spr_new_conf((out),false,SPR_COLORED_AUTO,true)
 #define spr_new_ttraced(out) spr_new_conf((out),true,SPR_COLORED_AUTO,true)
 #define spr_new_ctraced(out) spr_new_conf((out),false,SPR_COLORED_ALWAYS,true)
-#define spr_new_tctraced(out) spr_newconf((out),true,SPR_COLORED_ALWAYS,true)
+#define spr_new_tctraced(out) spr_new_conf((out),true,SPR_COLORED_ALWAYS,true)
 
 // Utility new() level + conf macros
 


### PR DESCRIPTION
## Description

Fixes a typo in the `spr_new_tctraced()` macro definition in `src/spuro.h` (line 149).

The macro was calling `spr_newconf(...)` instead of `spr_new_conf(...)` — missing an underscore between `new` and `conf`. All other macros in the same block use `spr_new_conf`, confirming this is a simple typo.

### Before
```c
#define spr_new_tctraced(out) spr_newconf((out),true,SPR_COLORED_ALWAYS,true)
```

### After
```c
#define spr_new_tctraced(out) spr_new_conf((out),true,SPR_COLORED_ALWAYS,true)
```

Fixes #12
